### PR TITLE
Add vim keys for navigating deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ uvx vercel-mgmt -t <bearer_token> -tid <team_id>
 
 ![](example.png)
 
-Set `VI_MODE=True` for vim navigation (`j`/`k` to move, `g`/`G` for top/bottom). In vim mode "keep only" moves from `k` to `K`.
+Set `VI_MODE=True` for vim navigation (`j`/`k` to move, `g`/`G` for top/bottom).
 
 ```
 VI_MODE=True uvx vercel-mgmt -t <bearer_token> -tid <team_id>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ uvx vercel-mgmt -t <bearer_token> -tid <team_id>
 
 ![](example.png)
 
+Set `VI_MODE=True` for vim navigation (`j`/`k` to move, `g`/`G` for top/bottom). In vim mode "keep only" moves from `k` to `K`.
+
+```
+VI_MODE=True uvx vercel-mgmt -t <bearer_token> -tid <team_id>
+```
+
 ```
 ## DEBUGGING
 # terminal 1

--- a/src/vercel_mgmt/mgmt.py
+++ b/src/vercel_mgmt/mgmt.py
@@ -6,7 +6,11 @@ from rich.text import Text
 from vercel_mgmt.vercel import Vercel
 import argparse
 import humanize
+import os
 from datetime import datetime
+
+
+VI_MODE = os.environ.get("VI_MODE", "").lower() in ("1", "true", "yes", "on")
 
 
 class VercelMGMT(App):
@@ -17,12 +21,13 @@ class VercelMGMT(App):
         ("r", "refresh", "Refresh"),
         ("space", "open", "Open Deployment"),
         ("c", "cancel", "Cancel Selected Deployments"),
-        ("K", "keep", "Keep Only Selected Deployments"),
+        ("K" if VI_MODE else "k", "keep", "Keep Only Selected Deployments"),
+    ] + ([
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
         Binding("g", "cursor_top", "Top", show=False),
         Binding("G", "cursor_bottom", "Bottom", show=False),
-    ]
+    ] if VI_MODE else [])
 
     def __init__(self, vercel: Vercel):
         super().__init__()

--- a/src/vercel_mgmt/mgmt.py
+++ b/src/vercel_mgmt/mgmt.py
@@ -1,5 +1,6 @@
 from textual import work, on
 from textual.app import App, ComposeResult
+from textual.binding import Binding
 from textual.widgets import Header, Footer, LoadingIndicator, DataTable
 from rich.text import Text
 from vercel_mgmt.vercel import Vercel
@@ -16,7 +17,11 @@ class VercelMGMT(App):
         ("r", "refresh", "Refresh"),
         ("space", "open", "Open Deployment"),
         ("c", "cancel", "Cancel Selected Deployments"),
-        ("k", "keep", "Keep Only Selected Deployments"),
+        ("K", "keep", "Keep Only Selected Deployments"),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+        Binding("g", "cursor_top", "Top", show=False),
+        Binding("G", "cursor_bottom", "Bottom", show=False),
     ]
 
     def __init__(self, vercel: Vercel):
@@ -64,6 +69,19 @@ class VercelMGMT(App):
         self.query_one(LoadingIndicator).display = True
         self.selected_deployments.clear()
         self.load_deployments()
+
+    def action_cursor_down(self) -> None:
+        self.query_one(DataTable).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        self.query_one(DataTable).action_cursor_up()
+
+    def action_cursor_top(self) -> None:
+        self.query_one(DataTable).move_cursor(row=0)
+
+    def action_cursor_bottom(self) -> None:
+        table = self.query_one(DataTable)
+        table.move_cursor(row=len(table.rows) - 1)
 
     def action_open(self) -> None:
         table = self.query_one(DataTable)


### PR DESCRIPTION
Adds vim-style movement to the deployments table:

- j / k — down / up
- g / G — top / bottom

Arrow keys still work as before. The only breaking bit: "keep only"
moved from k to K, since k is now "move up". The footer reflects the
new K automatically.
